### PR TITLE
Final fix to allow modifying PREFIX directory

### DIFF
--- a/loader/Makefile
+++ b/loader/Makefile
@@ -212,7 +212,7 @@ sd-loader:	$(DRVDIR)/dir-created
 ##################
 
 $(OBJDIR)/%.binary:	$(SPINDIR)/%.spin $(SPIN_SRCS)
-	@$(SPINCMP) -b $(SPINFLAGS) -o $@ $<
+	@${TARGET}/bin/$(SPINCMP) -b $(SPINFLAGS) -o $@ $<
 	@$(ECHO) $@
 
 $(OBJDIR)/%.c:	$(OBJDIR)/%.binary

--- a/loader/src/tools/bin2c.c
+++ b/loader/src/tools/bin2c.c
@@ -4,7 +4,7 @@
 
 int main(int argc, char *argv[])
 {
-    char base[100], opath[100], *name, *p;
+    char base[1024], opath[1024], *name, *p;
     FILE *ifp, *ofp;
     int byte, cnt;
 


### PR DESCRIPTION
Looks like the Makefile was depending on openspin existing on the path? I'm not sure how this would have worked even with the PREFIX being set to `/opt/parallax` though. Maybe `/opt/parallax` was added to the path prior to this Makefile execute?
